### PR TITLE
[COOK-3232] Ensure VDIR identifier trailing slash 

### DIFF
--- a/providers/app.rb
+++ b/providers/app.rb
@@ -1,5 +1,6 @@
 #
 # Author:: Kendrick Martin (kendrick.martin@webtrends.com)
+# Contributor:: Adam Wayne (awayne@waynedigital.com)
 # Cookbook Name:: iis
 # Provider:: app
 #
@@ -46,7 +47,7 @@ action :config do
   shell_out!(cmd)
 
   if @new_resource.physical_path
-    cmd = "#{appcmd} set vdir \"#{site_identifier}\""
+    cmd = "#{appcmd} set vdir \"#{vdir_identifier}\""
     cmd << " /physicalPath:\"#{@new_resource.physical_path}\""
     Chef::Log.debug(cmd)
     shell_out!(cmd) 
@@ -92,4 +93,9 @@ end
 
 def site_identifier
   "#{@new_resource.app_name}#{@new_resource.path}"
+end
+
+#Ensure VDIR identifier has a trailing slash
+def vdir_identifier
+  site_identifier.end_with?("/") ? site_identifier : site_identifier + "/"
 end

--- a/providers/app.rb
+++ b/providers/app.rb
@@ -46,7 +46,7 @@ action :config do
   shell_out!(cmd)
 
   if @new_resource.physical_path
-    cmd = "#{appcmd} set vdir \"#{site_identifier}\""
+    cmd = "#{appcmd} set vdir \"#{vdir_identifier}\""
     cmd << " /physicalPath:\"#{@new_resource.physical_path}\""
     Chef::Log.debug(cmd)
     shell_out!(cmd) 
@@ -92,4 +92,9 @@ end
 
 def site_identifier
   "#{@new_resource.app_name}#{@new_resource.path}"
+end
+
+#Ensure VDIR identifier has a trailing slash
+def vdir_identifier
+  site_identifier.end_with?("/") ? site_identifier : site_identifier + "/"
 end

--- a/providers/app.rb
+++ b/providers/app.rb
@@ -46,7 +46,7 @@ action :config do
   shell_out!(cmd)
 
   if @new_resource.physical_path
-    cmd = "#{appcmd} set vdir \"#{vdir_identifier}\""
+    cmd = "#{appcmd} set vdir \"#{site_identifier}\""
     cmd << " /physicalPath:\"#{@new_resource.physical_path}\""
     Chef::Log.debug(cmd)
     shell_out!(cmd) 
@@ -92,9 +92,4 @@ end
 
 def site_identifier
   "#{@new_resource.app_name}#{@new_resource.path}"
-end
-
-#Ensure VDIR identifier has a trailing slash
-def vdir_identifier
-  site_identifier.end_with?("/") ? site_identifier : site_identifier + "/"
 end


### PR DESCRIPTION
Added def vdir_identifier for VDIR identifier which ensures trailing slash, and modified APPCMD SET VDIR command to use new vdir_identifier.
